### PR TITLE
DFPL: Add fathersResponsibility to children objects

### DIFF
--- a/docs/specs/fpl-cafcass-api.json
+++ b/docs/specs/fpl-cafcass-api.json
@@ -843,6 +843,15 @@
           "solicitor": {
             "$ref": "#/components/schemas/solicitor",
             "description": "Filled in if the party is represented"
+          },
+          "fathersResponsibility": {
+            "type": "string",
+            "enum": [
+              "Yes",
+              "No",
+              "Don't know"
+            ],
+            "description": "Optional field to capture if the father has parental responsibility"
           }
         }
       },


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
 - Add fathersResponsibility subfield to children which is an optional field on the portal

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [NO] Does this PR introduce a breaking change
