### PR TITLE
DFPL-2588 Include solicitor's address in search response

### DIFF
--- a/docs/specs/fpl-cafcass-api.json
+++ b/docs/specs/fpl-cafcass-api.json
@@ -382,6 +382,10 @@
           "organisationId": {
             "type": "string",
             "example": "ABC281F"
+          },
+          "address": {
+            "$ref": "#/components/schemas/address",
+            "description": "Filled in if address exist"
           }
         }
       },
@@ -613,6 +617,9 @@
             "type": "string"
           },
           "addressLine2": {
+            "type": "string"
+          },
+          "addressLine3": {
             "type": "string"
           }
         }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DFPL-2588

### Change description
include the solicitor's address in the search cases API response.

Acceptance criteria
Given that a case where respondent / child solicitor has an address, when Cafcass searching the case, then the API should include the address in response.
The Swagger schema should be updated to reflect the requirement.
https://github.com/hmcts/cnp-api-docs/blob/master/docs/specs/fpl-cafcass-api.json

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [X] Does this PR introduce a breaking change
