### PR TITLE
Add support for OpenAPI 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "djv": "^2.1.4",
         "jasmine": "^4.3.0",
         "moment": "~2.29.4",
-        "swagger-ui-dist": "^4.13.0",
+        "swagger-ui-dist": "^5.18.2",
         "vis": "^4.21.0"
       },
       "devDependencies": {
@@ -24,6 +24,13 @@
       "resolved": "https://registry.npmjs.org/@korzio/djv-draft-04/-/djv-draft-04-2.0.1.tgz",
       "integrity": "sha512-MeTVcNsfCIYxK6T7jW1sroC7dBAb4IfLmQe6RoCqlxHN5NFkzNpgdnBPR+/0D2wJDUJHM9s9NQv+ouhxKjvUjg==",
       "optional": true
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -557,9 +564,13 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.13.0.tgz",
-      "integrity": "sha512-5yqhkUU9uV5oT/MTMBeSgDGI0Vx6eCOU43AszQBs88poI8OB1v+FoXEFHv+NaBbEfTkXCMWlAJrH6iWyDzLETQ=="
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.2.tgz",
+      "integrity": "sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
     },
     "node_modules/union": {
       "version": "0.5.0",
@@ -616,6 +627,11 @@
       "resolved": "https://registry.npmjs.org/@korzio/djv-draft-04/-/djv-draft-04-2.0.1.tgz",
       "integrity": "sha512-MeTVcNsfCIYxK6T7jW1sroC7dBAb4IfLmQe6RoCqlxHN5NFkzNpgdnBPR+/0D2wJDUJHM9s9NQv+ouhxKjvUjg==",
       "optional": true
+    },
+    "@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -1034,9 +1050,12 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.13.0.tgz",
-      "integrity": "sha512-5yqhkUU9uV5oT/MTMBeSgDGI0Vx6eCOU43AszQBs88poI8OB1v+FoXEFHv+NaBbEfTkXCMWlAJrH6iWyDzLETQ=="
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.2.tgz",
+      "integrity": "sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==",
+      "requires": {
+        "@scarf/scarf": "=1.4.0"
+      }
     },
     "union": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,14 @@
     "djv": "^2.1.4",
     "jasmine": "^4.3.0",
     "moment": "~2.29.4",
-    "swagger-ui-dist": "^4.13.0",
+    "swagger-ui-dist": "^5.18.2",
     "vis": "^4.21.0"
   },
   "devDependencies": {
     "http-server": "^14.1.1"
+  },
+  "scarfSettings": {
+    "enabled": false
   },
   "spec_dir": "test",
   "spec_files": [


### PR DESCRIPTION
### Jira link

N/A

### Change description

Updated swagger-ui-dist to a version that supports OpenAPI 3.1.0.  Under the current version an error containing "The provided definition does not specify a valid version field" is displayed when attempting to view an OpenAPI 3.1.0 specification.

Also added configuration to opt out of anonymised installation stats gathering (Scarf) that was added in swagger-ui-dist 5.18.0.

### Testing done

Built and ran application locally.  Was able to successfully view specifications that use swagger 2.0 (case_creation.json), OpenApi 3.0.0 (fpl-cafcass-api.json), OpenApi 3.0.1 (civil-service.json) and OpenApi 3.1.0 (pcs-api.json).

Note that `npm run update-swagger` needed to be run before OpenApi 3.1.0 specs could be viewed.  Unsure if changes made by this command need to be included in pull request or not.  Also unsure of `npm run update-vis` also needs to be run.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
